### PR TITLE
Support .pgpass files properly

### DIFF
--- a/ocdsdata/database.py
+++ b/ocdsdata/database.py
@@ -14,7 +14,7 @@ try:
     password = pgpasslib.getpass(host, port, user, dbname)
 
     database_uri = 'postgresql://{}:{}@{}/{}'.format(user, password, host, dbname)
-except FileNotFoundError:
+except pgpasslib.FileNotFound:
     database_uri = 'postgresql://{}:{}@{}/{}'.format(user, 'ocdsdata', host, dbname)
 
 DB_URI = os.environ.get('DB_URI', database_uri)

--- a/ocdsdata/database.py
+++ b/ocdsdata/database.py
@@ -13,11 +13,8 @@ dbname = 'ocdsdata'
 try:
     password = pgpasslib.getpass(host, port, user, dbname)
 
-    if not password:
-        raise ValueError('Did not find a password in the .pgpass file')
-
     database_uri = 'postgresql://{}:{}@{}/{}'.format(user, password, host, dbname)
-except ValueError:
+except FileNotFoundError:
     database_uri = 'postgresql://{}:{}@{}/{}'.format(user, 'ocdsdata', host, dbname)
 
 DB_URI = os.environ.get('DB_URI', database_uri)

--- a/ocdsdata/database.py
+++ b/ocdsdata/database.py
@@ -2,14 +2,23 @@ import sqlalchemy as sa
 import os
 from sqlalchemy.dialects.postgresql import JSONB
 from os.path import expanduser
- 
-try:
-    with open(expanduser('~/.pgpass'), 'r') as f:
-        host, port, database, user, password = f.read().rstrip().split(':')
+import pgpasslib
 
-    database_uri = 'postgresql://{}:{}@{}/{}'.format(user, password, host, database)
-except FileNotFoundError:
-    database_uri = 'postgres://ocdsdata:ocdsdata@localhost/ocdsdata'
+# Default database details
+host = 'localhost'
+port = '5432'
+user = 'ocdsdata'
+dbname = 'ocdsdata'
+
+try:
+    password = pgpasslib.getpass(host, port, user, dbname)
+
+    if not password:
+        raise ValueError('Did not find a password in the .pgpass file')
+
+    database_uri = 'postgresql://{}:{}@{}/{}'.format(user, password, host, dbname)
+except ValueError:
+    database_uri = 'postgresql://{}:{}@{}/{}'.format(user, 'ocdsdata', host, dbname)
 
 DB_URI = os.environ.get('DB_URI', database_uri)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ certifi==2018.1.18
 chardet==3.0.4
 idna==2.6
 more-itertools==4.1.0
+pgpasslib==1.1.0
 pluggy==0.6.0
 py==1.5.3
 pytest==3.5.0


### PR DESCRIPTION
On some further reading, it seems that the intention of .pgpass files is as a lookup database (keyed by host+port+user+db), rather than as a way of configuring connections. 

This PR switches to using `pgpasslib` and moves the db defaults into the code