### PR TITLE
Do we want to switch to psycopg2-binary?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ requests==2.18.4
 six==1.11.0
 urllib3==1.22
 SQLAlchemy==1.2.5
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 alembic==0.9.9
 ratelimit==1.4.1
 lxml==4.2.1


### PR DESCRIPTION
See http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/

In the future psycopg2 is becoming a source only package and if we want to keep using binaries we need to switch. On the other hand, apparently part of the reason for this is that for some people the binaries were causing problems - tho if you read the blog post it doesn't look like that applies to us? (Tho we can never be sure how others will use it, we don't use it with threads). Thoughts?