### PR TITLE
Add links to API documentation and bulk downloads

### DIFF
--- a/ocdskingfisher/sources/australia_nsw.py
+++ b/ocdskingfisher/sources/australia_nsw.py
@@ -6,6 +6,10 @@ from ocdskingfisher.util import save_content
 
 
 class AustraliaNSWSource(Source):
+    """
+    API documentation: https://github.com/NSW-eTendering/NSW-eTendering-API
+    """
+
     publisher_name = 'Australia NSW'
     url = 'https://tenders.nsw.gov.au'
     source_id = 'australia_nsw'

--- a/ocdskingfisher/sources/canada_buyandsell.py
+++ b/ocdskingfisher/sources/canada_buyandsell.py
@@ -2,6 +2,10 @@ from ocdskingfisher.base import Source
 
 
 class CanadaBuyAndSellSource(Source):
+    """
+    Bulk downloads: https://buyandsell.gc.ca/procurement-data/open-contracting-data-standard-pilot
+    """
+
     publisher_name = 'Buy And Sell'
     url = 'https://buyandsell.gc.ca'
     source_id = 'canada_buyandsell'

--- a/ocdskingfisher/sources/colombia.py
+++ b/ocdskingfisher/sources/colombia.py
@@ -3,6 +3,10 @@ from ocdskingfisher.base import Source
 
 
 class ColombiaSource(Source):
+    """
+    API documentation and bulk downloads: https://www.colombiacompra.gov.co/transparencia/gestion-documental/datos-abiertos
+    """
+
     publisher_name = 'Colombia'
     url = 'https://api.colombiacompra.gov.co'
     source_id = 'colombia'

--- a/ocdskingfisher/sources/mexico_administracion_publica_federal.py
+++ b/ocdskingfisher/sources/mexico_administracion_publica_federal.py
@@ -3,6 +3,10 @@ from ocdskingfisher.base import Source
 
 
 class MexicoAdministracionPublicaFederal(Source):
+    """
+    Bulk downloads: https://datos.gob.mx/busca/dataset/concentrado-de-contrataciones-abiertas-de-la-apf
+    """
+
     publisher_name = 'Mexico Administracion Publica Fedaral'
     url = 'https://api.datos.gob.mx/v1/contratacionesabiertas'
     source_id = 'mexico_administracion_publica_federal'

--- a/ocdskingfisher/sources/mexico_cdmx.py
+++ b/ocdskingfisher/sources/mexico_cdmx.py
@@ -3,6 +3,10 @@ from ocdskingfisher.base import Source
 
 
 class MexicoCDMXSource(Source):
+    """
+    API documentation: http://www.contratosabiertos.cdmx.gob.mx/datos-abiertos/documentacion-api-contratos
+    """
+
     publisher_name = 'Mexico CDMX'
     url = 'http://www.contratosabiertos.cdmx.gob.mx'
     source_id = 'mexico_cdmx'

--- a/ocdskingfisher/sources/mexico_inai.py
+++ b/ocdskingfisher/sources/mexico_inai.py
@@ -6,7 +6,7 @@ from ocdskingfisher.base import Source
 
 class MexicoINAISource(Source):
     publisher_name = 'Mexico > Instituto Nacional de Transparencia, Acceso a la Información y Protección de Datos Personales'
-    url = 'https://datos.gob.mx/busca/dataset?q=organization:inai'
+    url = 'https://datos.gob.mx/busca/organization/inai'
     source_id = 'mexico_inai'
 
     def gather_all_download_urls(self):

--- a/ocdskingfisher/sources/moldova.py
+++ b/ocdskingfisher/sources/moldova.py
@@ -2,6 +2,10 @@ from ocdskingfisher.base import Source
 
 
 class MoldovaSource(Source):
+    """
+    Bulk downloads: http://opencontracting.date.gov.md/downloads
+    """
+
     publisher_name = 'Moldova'
     url = 'http://data.dsp.im'
     source_id = 'moldova'

--- a/ocdskingfisher/sources/paraguay_dncp.py
+++ b/ocdskingfisher/sources/paraguay_dncp.py
@@ -13,6 +13,11 @@ REQUEST_TOKEN = "Basic " \
 
 
 class ParaguayDNCPSource(Source):
+    """
+    API documentation: https://www.contrataciones.gov.py/datos/api/v2/
+    Additional documentation: https://www.contrataciones.gov.py/datos/open-contracting-info
+    """
+
     publisher_name = 'Paraguay DNCP'
     url = 'https://www.contrataciones.gov.py/datos'
     source_id = 'paraguay_dncp'

--- a/ocdskingfisher/sources/taiwan.py
+++ b/ocdskingfisher/sources/taiwan.py
@@ -2,6 +2,10 @@ from ocdskingfisher.base import Source
 
 
 class TaiwanSource(Source):
+    """
+    Bulk downloads: http://data.dsp.im/dataset/taiwan-open-contracting
+    """
+
     publisher_name = 'Taiwan'
     url = 'http://data.dsp.im'
     source_id = 'taiwan'

--- a/ocdskingfisher/sources/uk_contracts_finder.py
+++ b/ocdskingfisher/sources/uk_contracts_finder.py
@@ -3,6 +3,10 @@ from ocdskingfisher.base import Source
 
 
 class UKContractsFinderSource(Source):
+    """
+    API documentation: https://www.gov.uk/government/publications/open-contracting
+    """
+
     publisher_name = 'UK Contracts Finder'
     url = 'https://www.contractsfinder.service.gov.uk'
     source_id = 'uk_contracts_finder'

--- a/ocdskingfisher/sources/ukraine.py
+++ b/ocdskingfisher/sources/ukraine.py
@@ -7,6 +7,11 @@ from ocdskingfisher.base import Source
 
 
 class UkraineSource(Source):
+    """
+    API documentation: http://api-docs.openprocurement.org/
+    API base URL: https://public.api.openprocurement.org/api/2.3/tenders
+    """
+
     publisher_name = 'Ukraine'
     url = 'http://ocds.prozorro.openprocurement.io/'
     source_id = 'ukraine'


### PR DESCRIPTION
To go along with https://github.com/open-contracting/sample-data/pull/79, I've moved links to API documentation that were only in `sample-data` into this repository, so that future work on scrapers won't need to hunt for API docs, etc.